### PR TITLE
DALi ports added to VCPKG.

### DIFF
--- a/ports/dali-adaptor/001_StyleMonitorFix.patch
+++ b/ports/dali-adaptor/001_StyleMonitorFix.patch
@@ -1,0 +1,13 @@
+diff --git a/dali/internal/styling/common/style-monitor-impl.cpp b/dali/internal/styling/common/style-monitor-impl.cpp
+index 5b316b47a..9b234342d 100644
+--- a/dali/internal/styling/common/style-monitor-impl.cpp
++++ b/dali/internal/styling/common/style-monitor-impl.cpp
+@@ -159,7 +159,7 @@ bool StyleMonitor::LoadThemeFile( const std::string& filename, std::string& outp
+ 
+   std::streampos bufferSize = 0;
+   Dali::Vector<char> fileBuffer;
+-  if( Dali::FileLoader::ReadFile( filename, bufferSize, fileBuffer, FileLoader::FileType::TEXT ) )
++  if( Dali::FileLoader::ReadFile( filename, bufferSize, fileBuffer, FileLoader::FileType::BINARY ) )
+   {
+     output.assign( &fileBuffer[0], bufferSize );
+     retval = true;

--- a/ports/dali-adaptor/CONTROL
+++ b/ports/dali-adaptor/CONTROL
@@ -1,0 +1,5 @@
+Source: dali-adaptor
+Version: 1.4.55
+Homepage: https://github.com/dalihub/dali-adaptor
+Description: DALi: Dynamic Animation Library - adaptor
+Build-Depends: winsock2, pthreads, curl, getopt-win32, libexif, libjpeg-turbo, libpng, giflib, angle, cairo, fontconfig, freetype, harfbuzz, fribidi, dali-core

--- a/ports/dali-adaptor/portfile.cmake
+++ b/ports/dali-adaptor/portfile.cmake
@@ -1,0 +1,45 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dalihub/dali-adaptor
+    REF 68442ef4cc4066a2c8e965826d5c2681bdd45b3f
+    SHA512 3d8ee053f8a3b204d5dafc6b468f15191fd1e0ef6a5ef6d9336cc77a369c21bc408b79daa164982ed6066204f426717073c42149170b96a7376ef4fbb217eb38
+    HEAD_REF master
+    PATCHES 
+        001_StyleMonitorFix.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  set(VCPKG_BUILD_SHARED_LIBS ON)
+else()
+  set(VCPKG_BUILD_SHARED_LIBS OFF)
+endif()
+
+set( ADAPTOR_OPTIONS
+       -DPROFILE_LCASE=windows
+       -DENABLE_PKG_CONFIGURE=OFF
+       -DENABLE_LINK_TEST=OFF
+       -DINSTALL_CMAKE_MODULES=1
+       -DSET_VCPKG_INSTALL_PREFIX=1
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}/build/tizen"
+    PREFER_NINJA
+    OPTIONS ${ADAPTOR_OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+#Install the license file.
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT} TARGET_PATH share/${PORT})
+
+vcpkg_copy_pdbs()
+
+# Copy the cmake configuration files to the 'installed' folder
+file( COPY "${CURRENT_PACKAGES_DIR}/share" DESTINATION ${CURRENT_INSTALLED_DIR} )
+
+vcpkg_test_cmake(PACKAGE_NAME dali-adaptor MODULE)

--- a/ports/dali-core/CONTROL
+++ b/ports/dali-core/CONTROL
@@ -1,0 +1,5 @@
+Source: dali-core
+Version: 1.4.55
+Homepage: https://github.com/dalihub/dali-core
+Description: DALi: Dynamic Animation Library - core
+Build-Depends: dali-windows-dependencies

--- a/ports/dali-core/portfile.cmake
+++ b/ports/dali-core/portfile.cmake
@@ -1,0 +1,41 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dalihub/dali-core
+    REF 8576e2d9d4b46749761f042a8ef694bf3ea62938
+    SHA512 6dc3ccd30f07228b89bbb4d59d747b881fdd1126a9da7950c4745e007c7cf79da885bbb37d59510eab9c22b211101883713ea7508c34789349c377950c3adb26
+    HEAD_REF master
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  set(VCPKG_BUILD_SHARED_LIBS ON)
+else()
+  set(VCPKG_BUILD_SHARED_LIBS OFF)
+endif()
+
+set( CORE_OPTIONS
+       -DENABLE_PKG_CONFIGURE=OFF
+       -DENABLE_LINK_TEST=OFF
+       -DINSTALL_CMAKE_MODULES=1
+       -DSET_VCPKG_INSTALL_PREFIX=1 )
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}/build/tizen"
+    PREFER_NINJA
+    OPTIONS ${CORE_OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+#Install the license file.
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT} TARGET_PATH share/${PORT})
+
+vcpkg_copy_pdbs()
+
+# Copy the cmake configuration files to the 'installed' folder
+file( COPY "${CURRENT_PACKAGES_DIR}/share" DESTINATION ${CURRENT_INSTALLED_DIR} )
+
+vcpkg_test_cmake(PACKAGE_NAME dali-core MODULE)

--- a/ports/dali-toolkit/CONTROL
+++ b/ports/dali-toolkit/CONTROL
@@ -1,0 +1,5 @@
+Source: dali-toolkit
+Version: 1.4.55
+Homepage: https://github.com/dalihub/dali-toolkit
+Description: DALi: Dynamic Animation Library - toolkit
+Build-Depends: dali-adaptor

--- a/ports/dali-toolkit/portfile.cmake
+++ b/ports/dali-toolkit/portfile.cmake
@@ -1,0 +1,47 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dalihub/dali-toolkit
+    REF 2b0beeb59996e7b52649eab32c9c5a964a894f08
+    SHA512 5dbbeafd904e1046d9c5b5b9e63983ad07d50202fe3286b6acc2ae5bac0ed749b634dade35284f1d7dc11027c686a1b0f4b5a3ff841749dcfff8fc698eb541a3
+    HEAD_REF master
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  set(VCPKG_BUILD_SHARED_LIBS ON)
+else()
+  set(VCPKG_BUILD_SHARED_LIBS OFF)
+endif()
+
+set( TOOLKIT_OPTIONS
+       -DENABLE_PKG_CONFIGURE=OFF
+       -DENABLE_LINK_TEST=OFF
+       -DINSTALL_DOXYGEN_DOC=OFF
+       -DCONFIGURE_AUTOMATED_TESTS=OFF
+       -DINSTALL_CMAKE_MODULES=1
+       -DSET_VCPKG_INSTALL_PREFIX=1
+       -DVCPKG_INSTALLED_DIR=${CURRENT_INSTALLED_DIR}
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}/build/tizen"
+    PREFER_NINJA
+    OPTIONS ${TOOLKIT_OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+#Install the license file.
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT} TARGET_PATH share/${PORT})
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+vcpkg_copy_pdbs()
+
+# Copy the cmake configuration files to the 'installed' folder
+file( COPY "${CURRENT_PACKAGES_DIR}/share" DESTINATION ${CURRENT_INSTALLED_DIR} )
+
+vcpkg_test_cmake(PACKAGE_NAME dali-toolkit MODULE)

--- a/ports/dali-windows-dependencies/CONTROL
+++ b/ports/dali-windows-dependencies/CONTROL
@@ -1,0 +1,4 @@
+Source: dali-windows-dependencies
+Version: 1.0
+Homepage: https://github.com/dalihub/windows-dependencies
+Description: DALi: Dynamic Animation Library - MS Windows dependencies

--- a/ports/dali-windows-dependencies/portfile.cmake
+++ b/ports/dali-windows-dependencies/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dalihub/windows-dependencies
+    REF 351fbbe59c19dcc45b08755a8314ec8e62a33b3a
+    SHA512 da933f1e293f2f099244dfbcad472cc123f4ee471e1ce0dc060f1ff945b55759f05273168ad32843ca7e2106fd88fa68c0734dfbce6929533f91da4d0f662780
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_SHARED_LIBS OFF)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}/build"
+    PREFER_NINJA
+    OPTIONS -DUSE_VCPKG=1
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+#Install the license file.
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT} TARGET_PATH share/${PORT})
+
+vcpkg_copy_pdbs()
+
+# Copy the cmake configuration files to the 'installed' folder
+file( COPY "${CURRENT_PACKAGES_DIR}/share" DESTINATION ${CURRENT_INSTALLED_DIR} )


### PR DESCRIPTION
* DALi version 1.4.55
* Builds and installs DALi on VCPKG.

Signed-off-by: Victor Cebollada <v.cebollada@samsung.com>